### PR TITLE
fix: the advertised receive window is never applied to what arrives

### DIFF
--- a/sctp/assoc_data.v
+++ b/sctp/assoc_data.v
@@ -253,12 +253,17 @@ fn (mut a Association) handle_data(data Data) ! {
 		a.schedule_sack(true)
 		return
 	}
-	closes_gap := data.tsn == a.last_received_tsn + 1
-	// The chunk that closes the gap is the one that drains everything held
-	// behind it, so the window is applied only to chunks that would extend the
-	// backlog. Refusing the closing chunk would deadlock the association against
-	// its own back pressure: the buffer stays full precisely because the thing
-	// that would empty it keeps being turned away.
+	// The chunk at the cumulative point is the one that drains everything held
+	// behind it, refusing it while the buffer is full would deadlock the
+	// association against its own back pressure: the buffer stays full precisely
+	// because the thing that would empty it keeps being turned away.
+	//
+	// That only holds while something is actually waiting on it. With no gap
+	// open nothing is behind this chunk and exempting it anyway would leave the
+	// window with no effect at all on a sender that stays in order which is
+	// every well behaved one and the easiest thing for a hostile one to do.
+	in_sequence := data.tsn == a.last_received_tsn + 1
+	closes_gap := in_sequence && a.out_of_order.len > 0
 	if !closes_gap {
 		if u32(data.user_data.len) > a.available_receive_window()
 			|| a.out_of_order.len >= max_out_of_order {
@@ -274,9 +279,9 @@ fn (mut a Association) handle_data(data Data) ! {
 
 	a.out_of_order[data.tsn] = data
 	a.receive_buffered += u32(data.user_data.len)
-	// A chunk that does not close the gap needs an immediate acknowledgement so
-	// the sender can fast-retransmit rather than wait for its timer.
-	gap_opened := !closes_gap
+	// A chunk that didn't arrive in sequence needs an immediate acknowledgement
+	// so the sender can fast retransmit rather than wait for its timer.
+	gap_opened := !in_sequence
 	a.advance_cumulative_ack()!
 
 	// RFC 4960 section 6.2 requires an acknowledgement at least every second

--- a/sctp/assoc_data.v
+++ b/sctp/assoc_data.v
@@ -249,11 +249,30 @@ fn (mut a Association) handle_data(data Data) ! {
 		a.schedule_sack(true)
 		return
 	}
+	closes_gap := data.tsn == a.last_received_tsn + 1
+	// The chunk that closes the gap is the one that drains everything held
+	// behind it, so the window is applied only to chunks that would extend the
+	// backlog. Refusing the closing chunk would deadlock the association against
+	// its own back pressure: the buffer stays full precisely because the thing
+	// that would empty it keeps being turned away.
+	if !closes_gap {
+		if u32(data.user_data.len) > a.available_receive_window()
+			|| a.out_of_order.len >= max_out_of_order {
+			// The peer was told there is no room. Dropping is what makes that
+			// advertisement mean something; a sender that respects it has
+			// nothing to retransmit and one that does not gets no memory out of
+			// us. The acknowledgement repeats the window in case the earlier one
+			// was lost.
+			a.schedule_sack(true)
+			return
+		}
+	}
 
 	a.out_of_order[data.tsn] = data
+	a.receive_buffered += u32(data.user_data.len)
 	// A chunk that does not close the gap needs an immediate acknowledgement so
 	// the sender can fast-retransmit rather than wait for its timer.
-	gap_opened := data.tsn != a.last_received_tsn + 1
+	gap_opened := !closes_gap
 	a.advance_cumulative_ack()!
 
 	// RFC 4960 section 6.2 requires an acknowledgement at least every second
@@ -302,7 +321,9 @@ fn (mut a Association) deliver(data Data) ! {
 // forward queues a message for the application.
 fn (mut a Association) forward(message Message) {
 	select {
-		a.delivered <- message {}
+		a.delivered <- message {
+			a.discharge(u32(message.data.len))
+		}
 		else {
 			// The application is not keeping up. Dropping here would break the
 			// reliability the stream promised, so the message is kept and the
@@ -386,21 +407,29 @@ fn (mut a Association) gap_block(start u32, end u32) GapAckBlock {
 
 // available_receive_window is what is left of the advertised buffer.
 //
-// Reporting it honestly is what makes back pressure work: a peer that is told
-// there is no room stops sending, and the application's own slowness reaches
-// the sender instead of being absorbed by an unbounded queue.
-fn (mut a Association) available_receive_window() u32 {
-	mut used := u32(0)
-	for _, data in a.out_of_order {
-		used += u32(data.user_data.len)
-	}
-	for message in a.held {
-		used += u32(message.data.len)
-	}
-	if used >= a.my_receive_window {
+// Reporting it honestly is what carries back pressure to a peer that respects
+// it and the application's own slowness reaches the sender rather than being
+// absorbed by an unbounded queue. handle_data applies the same figure to what
+// arrives which is what covers the peer that doesn't respect it.
+fn (a &Association) available_receive_window() u32 {
+	if a.receive_buffered >= a.my_receive_window {
 		return 0
 	}
-	return a.my_receive_window - used
+	return a.my_receive_window - a.receive_buffered
+}
+
+// discharge removes bytes from the receive accounting once they are no longer
+// retained.
+//
+// It saturates at zero rather than wrapping. An accounting slip that let the
+// counter drift should surface as a window that is slightly too generous, not
+// as an unsigned wrap that advertises four gigabytes of room.
+fn (mut a Association) discharge(bytes u32) {
+	if bytes >= a.receive_buffered {
+		a.receive_buffered = 0
+		return
+	}
+	a.receive_buffered -= bytes
 }
 
 // handle_sack processes an acknowledgement from the peer.
@@ -655,7 +684,9 @@ fn (mut a Association) handle_forward_tsn(forward ForwardTsn) {
 				identifier: stream.identifier
 			}
 		}
-		for message in inbound.skip_to(stream.sequence_number) {
+		messages, abandoned := inbound.skip_to(stream.sequence_number)
+		a.discharge(abandoned)
+		for message in messages {
 			a.forward(message)
 		}
 		a.inbound[stream.identifier] = inbound

--- a/sctp/association.v
+++ b/sctp/association.v
@@ -77,6 +77,11 @@ pub const default_rto_max = 60 * time.second
 // association is declared dead.
 pub const default_max_retransmits = 10
 
+// max_out_of_order bounds the gap list by entry count as well as by the receive
+// window because a window measured in bytes still admits a million single byte
+// chunks and every one of them is an entry build_sack has to sort.
+const max_out_of_order = 4096
+
 // default_sack_delay is how long acknowledgement is held back to let it ride
 // with outgoing data or cover several chunks (RFC 4960 section 6.2).
 pub const default_sack_delay = 200 * time.millisecond
@@ -210,6 +215,14 @@ mut:
 	// out_of_order holds TSNs received above the cumulative point, so they can
 	// be reported as gap blocks and delivered once the gap fills.
 	out_of_order map[u32]Data
+	// receive_buffered is the total payload retained on the receive side,
+	// wherever it currently sits: the gap list above, per stream reassembly,
+	// per stream ordering or the delivery backlog. Charging it where a chunk is
+	// accepted and discharging it where a message leaves for the application is
+	// what keeps the advertised window honest regardless of which of those the
+	// bytes happen to be in. Counting one of them, as a scan over that buffer
+	// would, leaves the others free to grow unwatched.
+	receive_buffered u32
 	// seen_duplicates are TSNs received again since the last acknowledgement.
 	seen_duplicates []u32
 

--- a/sctp/association.v
+++ b/sctp/association.v
@@ -111,7 +111,13 @@ pub:
 	role Role = .client
 	// streams is how many streams to offer in each direction.
 	streams u16 = default_streams
-	// receive_window is the buffer space advertised to the peer.
+	// receive_window is the buffer space advertised to the peer,and the figure
+	// handle_data holds arriving data to.
+	//
+	// It is closely rather than exactly enforced. The chunk at the cumulative
+	// point is accepted even when the buffer is full because it is the one that
+	// releases everything waiting behind it, so retention can exceed this by one
+	// chunk while a gap is being closed.
 	receive_window u32 = default_receive_window
 	// max_message_size bounds one reassembled message.
 	max_message_size int           = default_max_message_size

--- a/sctp/sctp_test.v
+++ b/sctp/sctp_test.v
@@ -1196,3 +1196,14 @@ fn test_a_collected_msg_stops_counting_against_the_window() {
 	assert a.held.len == 0, 'the backing array should be released once the backlog is empty'
 	assert a.held_head == 0
 }
+
+fn test_sender_that_never_leaves_a_gap_is_still_held_to_window() {
+	window := u32(64 * 1024)
+	mut a := established_receiver(window)
+	a.last_received_tsn = 0
+
+	for i in 0 .. 5000 {
+		a.handle_data(whole_message(u32(1 + i), 0, u16(i % 65535), 1024)) or { break }
+	}
+	assert a.receive_buffered <= window, 'retained ${a.receive_buffered} bytes against a ${window} byte window'
+}

--- a/sctp/sctp_test.v
+++ b/sctp/sctp_test.v
@@ -439,9 +439,11 @@ fn test_forward_tsn_skips_an_ordered_stream() {
 	// Sequence 2 arrives while 0 and 1 are still missing.
 	assert stream.accept(make_data(3, 2, 'third', true, true, false), default_max_message_size)!.len == 0
 	// The sender abandons 0 and 1; skipping to 1 releases what was waiting.
-	messages := stream.skip_to(1)
+	messages, abandoned := stream.skip_to(1)
 	assert messages.len == 1
 	assert messages[0].data == 'third'.bytes()
+	// Nothing was buffered for 0 or 1, so nothing was abandoned with them.
+	assert abandoned == 0
 }
 
 // -- Association over a pipe -----------------------------------------------
@@ -991,4 +993,131 @@ fn test_a_receive_on_a_closed_association_fails_rather_than_delivering_nothing()
 	if message := pair.client.try_recv() {
 		assert false, 'a closed association returned a ${message.data.len}-byte message'
 	}
+}
+
+// Receive window
+
+// IdleLink accepts writes and never delivers anything which is all a receive
+// side needs from its transport.
+struct IdleLink {
+mut:
+	writes int
+}
+
+fn (mut l IdleLink) write(data []u8) !int {
+	l.writes++
+	return data.len
+}
+
+fn (mut l IdleLink) read(timeout time.Duration) ![]u8 {
+	return error('idle')
+}
+
+fn (l &IdleLink) max_write() int {
+	return 1200
+}
+
+fn established_receiver(window u32) &Association {
+	mut a := Association.new(&IdleLink{}, role: .server, receive_window: window, streams: 1024) or {
+		panic(err)
+	}
+	a.state = .established
+	return a
+}
+
+fn whole_message(tsn u32, stream u16, sequence u16, size int) Data {
+	return Data{
+		tsn:                    tsn
+		stream_identifier:      stream
+		stream_sequence_number: sequence
+		user_data:              []u8{len: size}
+		beginning:              true
+		end:                    true
+	}
+}
+
+fn test_a_peer_never_closes_gap_is_held_to_window() {
+	window := u32(64 * 1024)
+	mut a := established_receiver(window)
+	a.last_received_tsn = 100
+
+	// 101 would close the gap and is never sent.
+	for i in 0 .. 5000 {
+		a.handle_data(whole_message(u32(102 + i), 0, u16(i), 1024)) or { break }
+	}
+
+	mut held := 0
+	for _, data in a.out_of_order {
+		held += data.user_data.len
+	}
+	assert u32(held) <= window, 'buffered ${held} bytes against a ${window} byte window'
+	assert a.available_receive_window() == 0, 'a full buffer should advertise no room'
+}
+
+fn test_a_peer_never_finishes_a_message_held_to_window() {
+	window := u32(64 * 1024)
+	mut a := established_receiver(window)
+	a.last_received_tsn = 0
+
+	// Every chunk is contiguous, each leaves the gap list at once and lands
+	// in reassembly. None of them ends its message.
+	for i in 0 .. 5000 {
+		a.handle_data(Data{
+			tsn:                    u32(1 + i)
+			stream_identifier:      0
+			stream_sequence_number: u16(i % 65535)
+			user_data:              []u8{len: 1024}
+			beginning:              true
+			end:                    false
+			unordered:              true
+		}) or { break }
+	}
+
+	mut retained := 0
+	for _, stream in a.inbound {
+		for _, partial in stream.partial {
+			retained += partial.total_bytes
+		}
+	}
+	assert u32(retained) <= window, 'reassembly retained ${retained} bytes against a ${window} byte window'
+}
+
+fn test_the_gap_list_is_bounded_by_entry_count() {
+	mut a := established_receiver(64 * 1024 * 1024)
+	a.last_received_tsn = 100
+
+	for i in 0 .. max_out_of_order * 2 {
+		a.handle_data(whole_message(u32(102 + i), 0, u16(i % 65535), 1)) or { break }
+	}
+	assert a.out_of_order.len <= max_out_of_order
+}
+
+fn test_a_full_buffer_still_accepts_the_chunk_that_drains_it() {
+	mut a := established_receiver(4096)
+	a.last_received_tsn = 100
+
+	// Fill the window with chunks that cannot be delivered yet.
+	for i in 0 .. 32 {
+		a.handle_data(whole_message(u32(102 + i), 0, u16(1 + i), 512)) or { break }
+	}
+	assert a.available_receive_window() == 0, 'the window should be full'
+
+	// 101 closes the gap. Everything contiguous behind it becomes deliverable.
+	a.handle_data(whole_message(101, 0, 0, 512))!
+	assert a.last_received_tsn > 101, 'the closing chunk did not drain the backlog'
+	assert a.available_receive_window() > 0, 'draining did not return the window'
+}
+
+// test_the_window_returns_as_messages_are_delivered : Delivered bytes are
+// no longer retained, so the room they occupied comes back.
+fn test_the_window_returns_as_messages_are_delivered() {
+	window := u32(64 * 1024)
+	mut a := established_receiver(window)
+	a.last_received_tsn = 0
+
+	for i in 0 .. 8 {
+		a.handle_data(whole_message(u32(1 + i), 0, u16(i), 1024))!
+	}
+	assert a.available_receive_window() == window, 'delivered messages should not stay charged'
+	assert a.receive_buffered == 0
 }

--- a/sctp/stream.v
+++ b/sctp/stream.v
@@ -28,6 +28,13 @@ pub const default_max_message_size = 262144
 // max_reassembly_fragments bounds how many fragments one message may take.
 const max_reassembly_fragments = 4096
 
+// max_partial_messages bounds how many messages one stream may have part way
+// through at once. Their bytes are already counted against the receive window,
+// but a peer that begins thousands of messages and finishes none would hold an
+// entry and a fragment list for each and the per message overhead is what a
+// byte count does not see.
+const max_partial_messages = 64
+
 // InboundStream reassembles and orders the messages arriving on one stream.
 struct InboundStream {
 mut:
@@ -85,6 +92,12 @@ fn (mut s InboundStream) accept(data Data, max_message_size int) ![]Message {
 	}
 
 	mut partial := s.partial[data.stream_sequence_number] or {
+		if s.partial.len >= max_partial_messages {
+			return DecodeError{
+				reason: .bad_value
+				detail: 'stream ${data.stream_identifier} has ${s.partial.len} messages part way through, more than ${max_partial_messages}'
+			}
+		}
 		PartialMessage{
 			payload_protocol_identifier: data.payload_protocol_identifier
 			unordered:                   data.unordered
@@ -160,13 +173,24 @@ fn (mut s InboundStream) deliver_ordered(sequence u16, message Message) []Messag
 
 // skip_to advances the ordered sequence past messages the sender abandoned,
 // which is what a FORWARD_TSN means for an ordered stream.
-fn (mut s InboundStream) skip_to(sequence u16) []Message {
+//
+// It returns the messages that became deliverable and the number of bytes it
+// abandoned. Those bytes were charged against the receive window when their
+// chunks arrived and nothing else is in a position to notice they have gone.
+fn (mut s InboundStream) skip_to(sequence u16) ([]Message, u32) {
 	// The comparison is on the wrapping 16-bit space, so a stream that has been
 	// running long enough to wrap is not stalled by it.
 	if !sequence_after(sequence, s.next_sequence) && sequence != s.next_sequence {
-		return []Message{}
+		return []Message{}, 0
 	}
+	mut abandoned := u32(0)
 	for s.next_sequence != sequence + 1 {
+		if partial := s.partial[s.next_sequence] {
+			abandoned += u32(partial.total_bytes)
+		}
+		if ready := s.ready[s.next_sequence] {
+			abandoned += u32(ready.data.len)
+		}
 		s.partial.delete(s.next_sequence)
 		s.ready.delete(s.next_sequence)
 		s.next_sequence++
@@ -178,7 +202,7 @@ fn (mut s InboundStream) skip_to(sequence u16) []Message {
 		s.ready.delete(s.next_sequence)
 		s.next_sequence++
 	}
-	return out
+	return out, abandoned
 }
 
 // OutboundStream tracks the sequence numbering for one stream we send on.


### PR DESCRIPTION
# Summary

<!-- What does this change, and why? One or two sentences. -->

`my_receive_window` was only ever advertised, never applied to arriving data, so a peer chose how much memory the receive side spent.

Closes #

## What breaks if this is wrong

A peer that completes DTLS can exhaust memory and stall the thread. Sending TSNs
above the cumulative point and never closing the gap buffered 20 MB against a
64 KiB window while `available_receive_window` correctly reported no room the
whole time. Bytes sitting in reassembly were not counted at all, so 20 MB could
be retained with the window reporting itself empty. `build_sack` sorts the gap
list on every acknowledgement, so the cost of acknowledging grew with whatever
the peer left outstanding. 33 ms per SACK at 80,000 chunks.

If *this change* is wrong, the failure is the opposite: legitimate data refused
or an association that stalls because back pressure never lifts.

<!--
The field reviewers read first. Be concrete: "a peer behind a symmetric NAT
never connects", "a malformed packet reads past the end of the buffer", "nothing
user-visible, this is a docs change".
-->

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change (the public API changes)
- [ ] Documentation
- [ ] Tests, tooling or CI

## Specification

<!--
If this implements or corrects a rule from an RFC, name it: "RFC 8445 section
7.3.1.1". If it does not, say "not applicable".
-->
RFC 4960 section 6.2 defines `a_rwnd` as the receiver's advertised buffer. The
RFC describes what a conforming sender does with it; this makes it hold against
one that does not. The count caps are hardening, not specified behaviour.

## Testing

- [ ] `make check` passes locally
- [x] New tests cover the change
- [x] A bug fix includes a test that fails without it
- [ ] A new decoder handles malformed input without panicking, and is included in
      the adversarial test

<!-- Describe what you tested and how, especially anything CI cannot cover. -->

## Checklist

- [ ] Formatted with `v fmt -w .`
- [x] No codec module gained a dependency on `net`
- [x] Any new limit on attacker-controlled input is documented on the constant
- [x] Public API has doc comments
- [ ] `CHANGELOG.md` updated under Unreleased, if the change is user-visible
- [x] No unrelated reformatting in the diff
