### PR TITLE
fix: messages held for a slow application are never delivered

### DIFF
--- a/sctp/assoc_data.v
+++ b/sctp/assoc_data.v
@@ -306,7 +306,7 @@ fn (mut a Association) deliver(data Data) ! {
 // forward queues a message for the application. The caller must hold the mutex.
 fn (mut a Association) forward(message Message) {
 	a.drain_held_locked()
-	if a.held.len > 0 {
+	if a.held_len() > 0 {
 		a.held << message
 		return
 	}
@@ -339,10 +339,12 @@ fn (mut a Association) drain_held_locked() {
 		return
 	}
 	mut moved := 0
-	for moved < a.held.len {
-		message := a.held[moved]
+	for a.held_head + moved < a.held.len {
+		index := a.held_head + moved
+		message := a.held[index]
 		select {
 			a.delivered <- message {
+				a.held[index] = Message{}
 				moved++
 			}
 			else {
@@ -353,7 +355,18 @@ fn (mut a Association) drain_held_locked() {
 	if moved == 0 {
 		return
 	}
-	a.held = a.held[moved..].clone()
+	a.held_head += moved
+	if a.held_head * 2 >= a.held.len {
+		a.held = a.held[a.held_head..].clone()
+		a.held_head = 0
+	}
+}
+
+// held_len is how many messages are still waiting. a.held keeps a delivered
+// prefix, so its length is not the answer.
+@[inline]
+fn (a &Association) held_len() int {
+	return a.held.len - a.held_head
 }
 
 // schedule_sack arranges for an acknowledgement.
@@ -437,8 +450,8 @@ fn (mut a Association) available_receive_window() u32 {
 	for _, data in a.out_of_order {
 		used += u32(data.user_data.len)
 	}
-	for message in a.held {
-		used += u32(message.data.len)
+	for i in a.held_head .. a.held.len {
+		used += u32(a.held[i].data.len)
 	}
 	if used >= a.my_receive_window {
 		return 0

--- a/sctp/assoc_data.v
+++ b/sctp/assoc_data.v
@@ -112,6 +112,9 @@ pub fn (mut a Association) recv(timeout time.Duration) !Message {
 			detail: 'the association is closed'
 		}
 	}
+	// The backlog is given its place in the queue before the queue is read.
+	// A message that had to wait is the next one collected rather than the last.
+	a.drain_held()
 	select {
 		message := <-a.delivered {
 			if message.data.len == 0 {
@@ -145,6 +148,7 @@ pub fn (mut a Association) recv(timeout time.Duration) !Message {
 
 // try_recv returns a message if one is already queued.
 pub fn (mut a Association) try_recv() ?Message {
+	a.drain_held()
 	select {
 		message := <-a.delivered {
 			if message.data.len == 0 {
@@ -299,8 +303,13 @@ fn (mut a Association) deliver(data Data) ! {
 	}
 }
 
-// forward queues a message for the application.
+// forward queues a message for the application. The caller must hold the mutex.
 fn (mut a Association) forward(message Message) {
+	a.drain_held_locked()
+	if a.held.len > 0 {
+		a.held << message
+		return
+	}
 	select {
 		a.delivered <- message {}
 		else {
@@ -311,6 +320,40 @@ fn (mut a Association) forward(message Message) {
 			a.held << message
 		}
 	}
+}
+
+// drain_held moves the backlog into the delivery queue, for callers that don't
+// already hold the mutex.
+fn (mut a Association) drain_held() {
+	a.mu.lock()
+	a.drain_held_locked()
+	a.mu.unlock()
+}
+
+// drain_held_locked moves as much of the backlog into the delivery queue as it
+// will take, oldest first. The caller must hold the mutex.
+fn (mut a Association) drain_held_locked() {
+	if a.closed {
+		// A closed association delivers nothing. What is still queued belongs to
+		// one that has ended and the channel it would go to is closed.
+		return
+	}
+	mut moved := 0
+	for moved < a.held.len {
+		message := a.held[moved]
+		select {
+			a.delivered <- message {
+				moved++
+			}
+			else {
+				break
+			}
+		}
+	}
+	if moved == 0 {
+		return
+	}
+	a.held = a.held[moved..].clone()
 }
 
 // schedule_sack arranges for an acknowledgement.

--- a/sctp/association.v
+++ b/sctp/association.v
@@ -268,6 +268,12 @@ mut:
 	// the advertised receive window, which is how the application's slowness
 	// reaches the sender rather than being absorbed by an unbounded queue.
 	held []Message
+	// held_head is where the waiting messages start. Everything before it has
+	// already been delivered and no longer retains the message payload; the
+	// slots are kept only so that collecting one message doesn't rebuild the
+	// array behind it and the compaction rule in drain_held_locked bounds how
+	// many of them there can be.
+	held_head int
 
 	closed bool
 	// torn_down separates "not started yet" from "finished". Both are the

--- a/sctp/sctp_test.v
+++ b/sctp/sctp_test.v
@@ -1005,7 +1005,7 @@ fn test_messages_past_the_delivery_queue_are_still_delivered() {
 			data:              'message ${i}'.bytes()
 		})
 	}
-	assert a.held.len > 0, 'the delivery queue should have overflowed'
+	assert a.held_len() > 0, 'the delivery queue should have overflowed'
 
 	mut seen := []string{}
 	for _ in 0 .. count {
@@ -1036,4 +1036,36 @@ fn test_a_backlog_is_delivered_in_the_order_it_was_queued() {
 	for i in 0 .. seen.len {
 		assert seen[i] == 'message ${i:04}', 'position ${i} holds ${seen[i]}'
 	}
+}
+
+fn test_a_collected_msg_stops_counting_against_the_window() {
+	mut pipe, _ := new_pipe_pair()
+	mut a := Association.new(pipe, role: .server, receive_window: 4 * 1024 * 1024)!
+	a.state = .established
+
+	count := 400
+	for _ in 0 .. count {
+		a.forward(Message{
+			stream_identifier: 0
+			data:              []u8{len: 1024}
+		})
+	}
+	assert a.held_len() > 0, 'the delivery queue should have overflowed'
+	before := a.available_receive_window()
+
+	for _ in 0 .. 32 {
+		a.try_recv() or { break }
+	}
+	assert a.available_receive_window() > before, 'collected messages must return their room'
+
+	for i in 0 .. a.held_head {
+		assert a.held[i].data.len == 0, 'slot ${i} was delivered but still holds its payload'
+	}
+
+	for _ in 0 .. count {
+		a.try_recv() or { break }
+	}
+	assert a.held_len() == 0
+	assert a.held.len == 0, 'the backing array should be released once the backlog is empty'
+	assert a.held_head == 0
 }

--- a/sctp/sctp_test.v
+++ b/sctp/sctp_test.v
@@ -992,3 +992,48 @@ fn test_a_receive_on_a_closed_association_fails_rather_than_delivering_nothing()
 		assert false, 'a closed association returned a ${message.data.len}-byte message'
 	}
 }
+
+fn test_messages_past_the_delivery_queue_are_still_delivered() {
+	mut pipe, _ := new_pipe_pair()
+	mut a := Association.new(pipe, role: .server)!
+	a.state = .established
+
+	count := 400
+	for i in 0 .. count {
+		a.forward(Message{
+			stream_identifier: 0
+			data:              'message ${i}'.bytes()
+		})
+	}
+	assert a.held.len > 0, 'the delivery queue should have overflowed'
+
+	mut seen := []string{}
+	for _ in 0 .. count {
+		message := a.try_recv() or { break }
+		seen << message.data.bytestr()
+	}
+	assert seen.len == count, 'collected ${seen.len} of ${count} messages'
+}
+
+fn test_a_backlog_is_delivered_in_the_order_it_was_queued() {
+	mut pipe, _ := new_pipe_pair()
+	mut a := Association.new(pipe, role: .server)!
+	a.state = .established
+
+	count := 400
+	for i in 0 .. count {
+		a.forward(Message{
+			stream_identifier: 0
+			data:              'message ${i:04}'.bytes()
+		})
+	}
+
+	mut seen := []string{}
+	for _ in 0 .. count {
+		message := a.try_recv() or { break }
+		seen << message.data.bytestr()
+	}
+	for i in 0 .. seen.len {
+		assert seen[i] == 'message ${i:04}', 'position ${i} holds ${seen[i]}'
+	}
+}


### PR DESCRIPTION
# Summary

<!-- What does this change, and why? One or two sentences. -->
Messages set aside when the delivery queue was full were appended to `a.held` and
never taken off again.

Closes #

## What breaks if this is wrong

<!--
The field reviewers read first. Be concrete: "a peer behind a symmetric NAT
never connects", "a malformed packet reads past the end of the buffer", "nothing
user-visible, this is a docs change".
-->

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change (the public API changes)
- [ ] Documentation
- [ ] Tests, tooling or CI

## Specification

This is an internal delivery bug
<!--
If this implements or corrects a rule from an RFC, name it: "RFC 8445 section
7.3.1.1". If it does not, say "not applicable".
-->

## Testing

- [ ] `make check` passes locally
- [x] New tests cover the change
- [x] A bug fix includes a test that fails without it
- [ ] A new decoder handles malformed input without panicking, and is included in
      the adversarial test

<!-- Describe what you tested and how, especially anything CI cannot cover. -->

## Checklist

- [x] Formatted with `v fmt -w .`
- [x] No codec module gained a dependency on `net`
- [x] Any new limit on attacker-controlled input is documented on the constant
- [x] Public API has doc comments
- [ ] `CHANGELOG.md` updated under Unreleased, if the change is user-visible
- [x] No unrelated reformatting in the diff
