### PR TITLE
fix: one message size limit is made to serve two different promises

### DIFF
--- a/connect.v
+++ b/connect.v
@@ -158,11 +158,15 @@ fn (mut pc PeerConnection) connect_sctp() ! {
 	// we will accept and it is what we advertised in turn. They are separate
 	// promises, so there is nothing to reconcile between them: a peer that
 	// accepts less than we do has not changed what we accept.
-	mut peer_max := config.max_message_size
+	//
+	// Nor is our own limit the fallback when the peer has said nothing. What a
+	// peer will reassemble is a fact about the peer and RFC 8841 section 6
+	// supplies the default for it. Reaching for config.max_message_size here
+	// would let an end configured to accept a megabyte send one to a peer whose
+	// effective limit is 64 KiB.
+	mut peer_max := default_remote_max_message_size
 	if remote := pc.remote {
-		if advertised := remote.max_message_size {
-			peer_max = advertised
-		}
+		peer_max = remote.max_message_size or { default_remote_max_message_size }
 	}
 	pc.mu.unlock()
 

--- a/connect.v
+++ b/connect.v
@@ -154,28 +154,24 @@ fn (mut pc PeerConnection) connect_sctp() ! {
 	mut conn := pc.dtls_conn
 	role := pc.role
 	config := pc.config
-	// The peer's advertised maximum bounds what we may send it; ours bounds
-	// what we will accept. Taking the smaller of the two for sending is what
-	// keeps a message from being dropped at the far end.
-	mut remote_max := config.max_message_size
+	// The peer's advertised maximum bounds what we may send it; ours bounds what
+	// we will accept and it is what we advertised in turn. They are separate
+	// promises, so there is nothing to reconcile between them: a peer that
+	// accepts less than we do has not changed what we accept.
+	mut peer_max := config.max_message_size
 	if remote := pc.remote {
 		if advertised := remote.max_message_size {
-			remote_max = advertised
+			peer_max = advertised
 		}
 	}
 	pc.mu.unlock()
 
-	max_message_size := if remote_max < config.max_message_size {
-		remote_max
-	} else {
-		config.max_message_size
-	}
-
 	// RFC 8841: the DTLS client is the SCTP client.
 	mut association := sctp.Association.new(conn,
-		role:             if role == .client { sctp.Role.client } else { sctp.Role.server }
-		max_message_size: max_message_size
-		logger:           config.logger
+		role:                  if role == .client { sctp.Role.client } else { sctp.Role.server }
+		max_message_size:      config.max_message_size
+		peer_max_message_size: peer_max
+		logger:                config.logger
 	) or {
 		return PeerError{
 			reason: .transport

--- a/description.v
+++ b/description.v
@@ -35,6 +35,12 @@ struct TransportParameters {
 }
 
 // build_description assembles an offer or an answer.
+// default_remote_max_message_size is what RFC 8841 section 6 says to assume when
+// a peer's data channel section carries no max-message-size attribute. It's a
+// fact about the peer, so our own configured limit is not a
+// substitute for it.
+const default_remote_max_message_size = 65536
+
 fn build_description(sections []Section, parameters TransportParameters, session_id u64, version u64, max_message_size int) !string {
 	mut description := sdp.SessionDescription{
 		version:      0
@@ -198,7 +204,12 @@ mut:
 	// candidates are any `a=candidate` lines carried in the description itself,
 	// which is how a non-trickling peer sends them.
 	candidates []string
-	// max_message_size is what the peer will accept on a data channel.
+	// max_message_size is what the peer will accept on a data channel, resolved
+	// as RFC 8841 section 6 defines it rather than as it was written: the
+	// advertised value or the default when the attribute is absent. Zero is
+	// carried through unchanged and means the peer will take any size.
+	//
+	// It's none only when the description carried no data channel section at all.
 	max_message_size ?int
 	parsed           sdp.SessionDescription
 }
@@ -284,14 +295,15 @@ fn parse_remote_description(text string) !RemoteDescription {
 		for line in media.candidates() {
 			remote.candidates << line
 		}
-		if size := media.max_message_size() {
-			// RFC 8841 section 6: zero is the absence of a limit, not a limit of
-			// nothing. A value past what an int holds is treated the same way
-			// because a limit that cannot be represented cannot be applied.
-			// Both then mean what a missing attribute means which leaves one
-			// case downstream instead of three.
-			if size != 0 && size <= u32(max_i32) {
-				remote.max_message_size = int(size)
+		if kind == .application {
+			if size := media.max_message_size() {
+				remote.max_message_size = if size > u32(max_i32) {
+					int(max_i32)
+				} else {
+					int(size)
+				}
+			} else {
+				remote.max_message_size = default_remote_max_message_size
 			}
 		}
 		if remote.ice_ufrag == '' {

--- a/description.v
+++ b/description.v
@@ -285,7 +285,14 @@ fn parse_remote_description(text string) !RemoteDescription {
 			remote.candidates << line
 		}
 		if size := media.max_message_size() {
-			remote.max_message_size = int(size)
+			// RFC 8841 section 6: zero is the absence of a limit, not a limit of
+			// nothing. A value past what an int holds is treated the same way
+			// because a limit that cannot be represented cannot be applied.
+			// Both then mean what a missing attribute means which leaves one
+			// case downstream instead of three.
+			if size != 0 && size <= u32(max_i32) {
+				remote.max_message_size = int(size)
+			}
 		}
 		if remote.ice_ufrag == '' {
 			if ufrag := parsed.ice_ufrag(media) {

--- a/peer_connection.v
+++ b/peer_connection.v
@@ -106,6 +106,13 @@ pub fn PeerConnection.new(config Configuration) !&PeerConnection {
 	}
 }
 
+// peer_max_message_size is the largest data channel message the peer said it
+// will accept once the association has been established.
+pub fn (pc &PeerConnection) peer_max_message_size() ?int {
+	association := pc.association or { return none }
+	return association.peer_max_message_size()
+}
+
 // local_fingerprint is the certificate fingerprint this connection publishes.
 pub fn (pc &PeerConnection) local_fingerprint() dtls.Fingerprint {
 	return pc.certificate.fingerprint(.sha256)

--- a/sctp/assoc_data.v
+++ b/sctp/assoc_data.v
@@ -41,7 +41,9 @@ pub fn (mut a Association) send(stream_identifier u16, payload_protocol_identifi
 			detail: 'stream ${stream_identifier} is outside the ${a.config.streams} negotiated'
 		}
 	}
-	if data.len > a.config.peer_max_message_size {
+	// Zero is not a limit of nothing: it is the peer saying it will reassemble
+	// whatever arrives, so there is nothing to compare against.
+	if a.config.peer_max_message_size > 0 && data.len > a.config.peer_max_message_size {
 		return AssociationError{
 			reason: .too_large
 			detail: '${data.len} bytes exceeds the ${a.config.peer_max_message_size}-byte maximum the peer accepts'

--- a/sctp/assoc_data.v
+++ b/sctp/assoc_data.v
@@ -41,10 +41,10 @@ pub fn (mut a Association) send(stream_identifier u16, payload_protocol_identifi
 			detail: 'stream ${stream_identifier} is outside the ${a.config.streams} negotiated'
 		}
 	}
-	if data.len > a.config.max_message_size {
+	if data.len > a.config.peer_max_message_size {
 		return AssociationError{
 			reason: .too_large
-			detail: '${data.len} bytes exceeds the ${a.config.max_message_size}-byte maximum'
+			detail: '${data.len} bytes exceeds the ${a.config.peer_max_message_size}-byte maximum the peer accepts'
 		}
 	}
 

--- a/sctp/association.v
+++ b/sctp/association.v
@@ -112,12 +112,14 @@ pub:
 	// accept and the figure to advertise to the peer.
 	max_message_size int = default_max_message_size
 	// peer_max_message_size bounds one message sent because it is the figure
-	// the peer advertised for its own reassembly.
+	// the peer advertised for its own reassembly. Zero means the peer will take
+	// any size which is how RFC 8841 section 6 spells no limit and is carried
+	// here unchanged rather than encoded as some large number.
 	//
 	// It is separate from max_message_size because the two are separate
 	// promises. Collapsing them to the smaller of the pair lets a peer that
 	// accepts less than we do also shrink what we accept, below the figure we
-	// ourselves advertised. And the association then aborts on a message we
+	// ourselves advertised and the association then aborts on a message we
 	// said we would take.
 	peer_max_message_size int           = default_max_message_size
 	rto_initial      time.Duration = default_rto_initial
@@ -309,10 +311,10 @@ pub fn Association.new(transport Transport, config Config) !&Association {
 			detail: 'max_message_size must be positive'
 		}
 	}
-	if config.peer_max_message_size <= 0 {
+	if config.peer_max_message_size < 0 {
 		return AssociationError{
 			reason: .wrong_state
-			detail: 'peer_max_message_size must be positive'
+			detail: 'peer_max_message_size cannot be negative'
 		}
 	}
 
@@ -372,7 +374,8 @@ pub fn (a &Association) max_message_size() int {
 	return a.config.max_message_size
 }
 
-// peer_max_message_size is the largest message the peer said it will accept.
+// peer_max_message_size is the largest message the peer said it will accept or
+// zero if it will accept any size.
 //
 // A caller that does its own segmentation on top of a data channel needs this
 // rather than its own limit because the message has to survive reassembly at

--- a/sctp/association.v
+++ b/sctp/association.v
@@ -108,8 +108,18 @@ pub:
 	streams u16 = default_streams
 	// receive_window is the buffer space advertised to the peer.
 	receive_window u32 = default_receive_window
-	// max_message_size bounds one reassembled message.
-	max_message_size int           = default_max_message_size
+	// max_message_size bounds one reassembled message: the largest this end will
+	// accept and the figure to advertise to the peer.
+	max_message_size int = default_max_message_size
+	// peer_max_message_size bounds one message sent because it is the figure
+	// the peer advertised for its own reassembly.
+	//
+	// It is separate from max_message_size because the two are separate
+	// promises. Collapsing them to the smaller of the pair lets a peer that
+	// accepts less than we do also shrink what we accept, below the figure we
+	// ourselves advertised. And the association then aborts on a message we
+	// said we would take.
+	peer_max_message_size int           = default_max_message_size
 	rto_initial      time.Duration = default_rto_initial
 	rto_min          time.Duration = default_rto_min
 	rto_max          time.Duration = default_rto_max
@@ -299,6 +309,12 @@ pub fn Association.new(transport Transport, config Config) !&Association {
 			detail: 'max_message_size must be positive'
 		}
 	}
+	if config.peer_max_message_size <= 0 {
+		return AssociationError{
+			reason: .wrong_state
+			detail: 'peer_max_message_size must be positive'
+		}
+	}
 
 	// The verification tag and the initial TSN are both random. The tag is what
 	// stops an off-path attacker from injecting into the association, and a
@@ -350,10 +366,20 @@ pub fn (a &Association) role() Role {
 	return if a.is_client { Role.client } else { Role.server }
 }
 
-// max_message_size is the largest message this association will send or accept.
+// max_message_size is the largest message this association will accept.
 @[inline]
 pub fn (a &Association) max_message_size() int {
 	return a.config.max_message_size
+}
+
+// peer_max_message_size is the largest message the peer said it will accept.
+//
+// A caller that does its own segmentation on top of a data channel needs this
+// rather than its own limit because the message has to survive reassembly at
+// the far end.
+@[inline]
+pub fn (a &Association) peer_max_message_size() int {
+	return a.config.peer_max_message_size
 }
 
 // is_closed reports whether the association has been shut down.

--- a/sctp/sctp_test.v
+++ b/sctp/sctp_test.v
@@ -755,7 +755,7 @@ fn test_send_rejects_an_unknown_stream() {
 }
 
 fn test_send_rejects_an_oversized_message() {
-	mut pair := connect_pair(max_message_size: 1000)!
+	mut pair := connect_pair(peer_max_message_size: 1000)!
 	defer {
 		pair.client.close()
 		pair.server.close()
@@ -991,4 +991,63 @@ fn test_a_receive_on_a_closed_association_fails_rather_than_delivering_nothing()
 	if message := pair.client.try_recv() {
 		assert false, 'a closed association returned a ${message.data.len}-byte message'
 	}
+}
+
+// The two message limits
+
+fn test_a_peers_smaller_limit_does_not_shrink_what_we_accept() {
+	mut client_pipe, mut server_pipe := new_pipe_pair()
+	// The client accepts 64 KiB and advertised as much. Its peer happens to
+	// accept only 1 KiB which is a fact about the peer and not about the
+	// client. The server is free to send what the client advertised.
+	mut pair := connect_over_with(mut client_pipe, mut server_pipe, Config{
+		max_message_size:      64 * 1024
+		peer_max_message_size: 1024
+	}, Config{
+		max_message_size:      1024
+		peer_max_message_size: 64 * 1024
+	})!
+	defer {
+		pair.client.close()
+		pair.server.close()
+	}
+
+	body := []u8{len: 16 * 1024, init: u8(index & 0xff)}
+	pair.server.send(0, ppid_binary, body, true)!
+	message := pair.client.recv(5 * time.second)!
+	assert message.data.len == body.len
+	assert message.data == body
+}
+
+// A message the peer cannot reassemble is refused here rather than sent and
+// abandoned there and the error names the limit that refused it.
+fn test_sending_is_bounded_by_what_the_peer_accepts() {
+	mut pair := connect_pair(Config{
+		max_message_size:      64 * 1024
+		peer_max_message_size: 1024
+	})!
+	defer {
+		pair.client.close()
+		pair.server.close()
+	}
+	pair.client.send(0, ppid_binary, []u8{len: 2048}, true) or {
+		assert err is AssociationError
+		if err is AssociationError {
+			assert err.reason == .too_large
+		}
+		assert err.msg().contains('the peer accepts')
+		return
+	}
+	assert false, 'a message the peer cannot reassemble must be refused here'
+}
+
+fn test_reassembly_is_bounded_by_our_own_limit() {
+	mut stream := InboundStream{
+		identifier: 1
+	}
+	// 4 KiB in two fragments, against a 64 KiB limit of our own.
+	assert stream.accept(make_data(1, 0, 'a'.repeat(2048), true, false, false), 64 * 1024)!.len == 0
+	messages := stream.accept(make_data(2, 0, 'b'.repeat(2048), false, true, false), 64 * 1024)!
+	assert messages.len == 1
+	assert messages[0].data.len == 4096
 }

--- a/sctp/sctp_test.v
+++ b/sctp/sctp_test.v
@@ -1051,3 +1051,21 @@ fn test_reassembly_is_bounded_by_our_own_limit() {
 	assert messages.len == 1
 	assert messages[0].data.len == 4096
 }
+
+// RFC 8841 section 6: a peer advertising zero will reassemble a message of any
+// size. Refusing to send on that basis would be reading it as a limit of
+// nothing which is the opposite of what it says.
+fn test_a_peer_that_accepts_any_size_is_not_a_peer_that_accepts_nothing() {
+	mut pair := connect_pair(Config{
+		max_message_size:      64 * 1024
+		peer_max_message_size: 0
+	})!
+	defer {
+		pair.client.close()
+		pair.server.close()
+	}
+	body := []u8{len: 32 * 1024, init: u8(index & 0xff)}
+	pair.client.send(0, ppid_binary, body, true)!
+	message := pair.server.recv(5 * time.second)!
+	assert message.data == body
+}

--- a/webrtc_test.v
+++ b/webrtc_test.v
@@ -475,3 +475,32 @@ fn test_the_direction_of_an_answer_is_the_mirror_of_the_offer() {
 	assert answer.sdp.contains('a=recvonly')
 	assert sdp.Direction.sendonly.reverse() == sdp.Direction.recvonly
 }
+
+fn description_with_max_message_size(value string) string {
+	return 'v=0\r\no=- 1 1 IN IP4 127.0.0.1\r\ns=-\r\nt=0 0\r\n' +
+		'm=application 9 UDP/DTLS/SCTP webrtc-datachannel\r\nc=IN IP4 0.0.0.0\r\n' +
+		'a=ice-ufrag:abcd\r\na=ice-pwd:0123456789012345678901\r\na=mid:0\r\n' +
+		'a=fingerprint:sha-256 75:74:5A:A6:A4:E5:52:F4:A7:67:4C:01:C7:EE:91:3F:21:3D:A2:E3:53:7B:6F:30:86:F2:30:AA:65:FB:04:24\r\n' +
+		'a=setup:active\r\na=sctp-port:5000\r\n' + value
+}
+
+fn test_a_peer_may_advertise_a_smaller_message_size() {
+	remote := parse_remote_description(description_with_max_message_size('a=max-message-size:65536\r\n'))!
+	assert remote.max_message_size? == 65536
+}
+
+// RFC 8841 section 6
+fn test_a_max_message_size_of_zero_means_no_limit() {
+	remote := parse_remote_description(description_with_max_message_size('a=max-message-size:0\r\n'))!
+	assert remote.max_message_size == none
+}
+
+fn test_a_max_message_size_beyond_an_int_is_not_neg_limit() {
+	remote := parse_remote_description(description_with_max_message_size('a=max-message-size:4294967295\r\n'))!
+	assert remote.max_message_size == none
+}
+
+fn test_a_desc_without_max_mesg_size_leaves_it_unset() {
+	remote := parse_remote_description(description_with_max_message_size(''))!
+	assert remote.max_message_size == none
+}

--- a/webrtc_test.v
+++ b/webrtc_test.v
@@ -489,18 +489,31 @@ fn test_a_peer_may_advertise_a_smaller_message_size() {
 	assert remote.max_message_size? == 65536
 }
 
-// RFC 8841 section 6
-fn test_a_max_message_size_of_zero_means_no_limit() {
+// RFC 8841 section 6: zero means the peer will handle a message of any size.
+fn test_a_max_message_size_of_zero_means_any_size() {
 	remote := parse_remote_description(description_with_max_message_size('a=max-message-size:0\r\n'))!
-	assert remote.max_message_size == none
+	assert remote.max_message_size? == 0
 }
 
-fn test_a_max_message_size_beyond_an_int_is_not_neg_limit() {
-	remote := parse_remote_description(description_with_max_message_size('a=max-message-size:4294967295\r\n'))!
-	assert remote.max_message_size == none
-}
-
-fn test_a_desc_without_max_mesg_size_leaves_it_unset() {
+fn test_a_desc_without_max_mesg_size_takes_the_rfc_default() {
 	remote := parse_remote_description(description_with_max_message_size(''))!
-	assert remote.max_message_size == none
+	assert remote.max_message_size? == default_remote_max_message_size
+	assert remote.max_message_size? == 65536
+}
+
+fn test_a_max_message_size_beyond_an_int_is_clamped() {
+	remote := parse_remote_description(description_with_max_message_size('a=max-message-size:4294967295\r\n'))!
+	assert remote.max_message_size? == int(max_i32)
+}
+
+fn test_a_media_section_does_not_overwrite_the_message_size() {
+	text := 'v=0\r\no=- 1 1 IN IP4 127.0.0.1\r\ns=-\r\nt=0 0\r\n' +
+		'a=fingerprint:sha-256 75:74:5A:A6:A4:E5:52:F4:A7:67:4C:01:C7:EE:91:3F:21:3D:A2:E3:53:7B:6F:30:86:F2:30:AA:65:FB:04:24\r\n' +
+		'a=ice-ufrag:abcd\r\na=ice-pwd:0123456789012345678901\r\n' +
+		'm=application 9 UDP/DTLS/SCTP webrtc-datachannel\r\nc=IN IP4 0.0.0.0\r\n' +
+		'a=mid:0\r\na=setup:active\r\na=sctp-port:5000\r\na=max-message-size:262144\r\n' +
+		'm=audio 9 UDP/TLS/RTP/SAVPF 111\r\nc=IN IP4 0.0.0.0\r\na=mid:1\r\n' +
+		'a=rtpmap:111 opus/48000/2\r\na=sendrecv\r\n'
+	remote := parse_remote_description(text)!
+	assert remote.max_message_size? == 262144
 }


### PR DESCRIPTION
# Summary

The peer's advertised message size and our own were collapsed into one field
that the association reads for both sending and reassembly.

Closes #

## What breaks if this is wrong

<!--
The field reviewers read first. Be concrete: "a peer behind a symmetric NAT
never connects", "a malformed packet reads past the end of the buffer", "nothing
user-visible, this is a docs change".
-->

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change (the public API changes)
- [ ] Documentation
- [ ] Tests, tooling or CI

## Specification

RFC 8841 section 6 : `a=max-message-size`, including the meaning of zero. RFC
8831 for the data channel limits it bounds.

## Testing

- [ ] `make check` passes locally
- [x] New tests cover the change
- [x] A bug fix includes a test that fails without it
- [ ] A new decoder handles malformed input without panicking, and is included in
      the adversarial test

<!-- Describe what you tested and how, especially anything CI cannot cover. -->

## Checklist

- [x] Formatted with `v fmt -w .`
- [x] No codec module gained a dependency on `net`
- [x] Any new limit on attacker-controlled input is documented on the constant
- [x] Public API has doc comments
- [ ] `CHANGELOG.md` updated under Unreleased, if the change is user-visible
- [x] No unrelated reformatting in the diff
